### PR TITLE
Attach Event Name to Error

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: "https://www.getelevar.com"
 documentation: "https://github.com/getelevar/gtm-monitoring-variables/blob/master/README.md"
 versions:
+  - sha: a9d3c20e04fc06f73a2caded55bbe5be478a6668
+    changeNotes: Get Event Name with built in functions and add version to template to keep track of changes.
   - sha: 14e4407e08ca58a00bd1071d868d9163ec9a2d3b
     changeNotes: Initial release.


### PR DESCRIPTION
Part of https://github.com/getelevar/elevar-monorepo/issues/108
Related to https://github.com/getelevar/gtm-monitoring-core/pull/7

Add version number to the template.

Get Event Name with `copyFromDataLayer('event')` instead of trying to get it in the core template with the ID. This is a more reliable way and should fix the issues with event_name being false or undefined.