### PR TITLE
Warn on unsupported variable keys

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://www.getelevar.com"
 documentation: "https://github.com/getelevar/gtm-monitoring-variables/blob/master/README.md"
 versions:
+  - sha: 6c1741ab406aaa916449ae22ea7327e32629ba8d
+    changeNotes: Add regexp to validate data layer keys against and provide valuable information to template users.
   - sha: a9d3c20e04fc06f73a2caded55bbe5be478a6668
     changeNotes: Get Event Name with built in functions and add version to template to keep track of changes.
   - sha: 14e4407e08ca58a00bd1071d868d9163ec9a2d3b

--- a/template.tpl
+++ b/template.tpl
@@ -11,7 +11,11 @@ ___INFO___
 {
   "displayName": "Elevar Monitoring Variable",
   "description": "Add tracking and validation to your variable values, make sure no errors go unnoticed \u0026 fix critical errors immediately.\n\nThe variables work in combination with The Elevar Monitoring Core Tag.",
-  "categories": ["UTILITY", "ANALYTICS", "TAG_MANAGEMENT"],
+  "categories": [
+    "UTILITY",
+    "ANALYTICS",
+    "TAG_MANAGEMENT"
+  ],
   "securityGroups": [],
   "id": "cvt_temp_public_id",
   "type": "MACRO",
@@ -46,6 +50,13 @@ ___TEMPLATE_PARAMETERS___
     "valueValidators": [
       {
         "type": "NON_EMPTY"
+      },
+      {
+        "type": "REGEX",
+        "args": [
+          "/(^(ecommerce\\..*)$|^(ecommerce|VariantPrice|VisitorType|orderEmail|CustomerPhone|CustomerLastName|CustomerFirstName|SearchTerms|CustomerEmail|visitorId|visitorType|CustomerId|CustomerOrdersCount|CustomerTotalSpent|pageType|cartTotal|shopifyProductId|VariantCompareAtPrice|cartItems|event|discountTotalAmount|discountTotalSavings|CustomerCity|CustomerZip|CustomerAddress1|CustomerAddress2|CustomerCountryCode|CustomerProvince|CustomerOrdersCount)$)/"
+        ],
+        "errorMessage": "This key is currently not supported by the template. Reach out to help@getelevar.com if you think it should be."
       }
     ],
     "valueHint": "ecommerce.purchase.products"


### PR DESCRIPTION
Add regex that warns if variable key is not supported.

Should help in catching issues with unsupported variable keys in templates.

related to https://github.com/getelevar/elevar-monorepo/issues/459

**Note:** Merging this PR will trigger a new release in GTM!